### PR TITLE
Adding the `setAttr` module

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -85,6 +85,25 @@
 
     <hr>
 
+    <h2>Set Attribute</h2>
+
+    <div class="row">
+      <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+          <label for="" class="control-label">Enter a value here…</label>
+          <input type="text" class="form-control" data-if-set-attr="targetElement|value">
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+          <label for="" class="control-label">…and it will end up here.</label>
+          <input type="text" class="form-control" data-if-set-attr-output="targetElement" disabled>
+        </div>
+      </div>
+    </div>
+
+    <hr>
+
     <h2>Validate Form</h2>
 
     <form action="#" data-if-validate-form>

--- a/src/controllers/if.controller.disable.ts
+++ b/src/controllers/if.controller.disable.ts
@@ -44,7 +44,9 @@ export default function disable(): Controller {
   const events: Global.MethodObject = {
     initOnLoad: () => {
       window.onload = () => {
-        const { target, condition } = targets;
+        const target = targets.target as NodeListOf<HTMLInputElement>;
+        const condition = targets.target as NodeListOf<HTMLInputElement>;
+
         disableModule(target, condition).init();
       };
     }

--- a/src/controllers/if.controller.setAttr.ts
+++ b/src/controllers/if.controller.setAttr.ts
@@ -1,0 +1,72 @@
+import { Global } from '../../typings.d';
+
+/**
+ * @file The controller for the `setAttr` module.
+ *
+ * @author Justin Toon
+ * @license MIT
+ *
+ * @version 0.2.0
+ *
+ * @requires NPM:lodash-es
+ * @requires NPM:inflection
+ * @requires ../config/if.controller.js:controller
+ * @requires ../if.utils.js:createDataFieldSelector
+ */
+
+import { includes, isArray, last } from 'lodash-es';
+
+import Controller from '../config/if.controller';
+import setAttrModule from '../modules/if.module.setAttr';
+
+/**
+ * The initialization function for creating the `setAttr` {@link Controller}.
+ *
+ * @since 0.2.0
+ * @returns {Controller}
+ */
+export default function setAttr(): Controller {
+  /**
+   * The name of the controller.
+   *
+   * @const
+   * @type {string}
+   */
+  const name = 'setAttr';
+
+  /**
+   * Selector strings for the `validateForm` {@link Controller}.
+   *
+   * @const
+   * @type {Object}
+   */
+  const targets: Global.NodeListObject<HTMLElement> = Controller.getTargets(name);
+
+  /**
+   * Events created for the `validateForm` {@link Controller}.
+   *
+   * @const
+   * @type {Object}
+   */
+  const events: Global.MethodObject = {
+    changeOrClick: function eventsSetAttrChangeOrClick() {
+      [].slice.call(targets.target).forEach(target => {
+        target.addEventListener('change', beginInit);
+        target.addEventListener('click', beginInit);
+      });
+
+      /**
+       * Callback from event listeners in `eventsSetAttrChangeOrClick`.
+       *
+       * @callback
+       * @protected
+       * @param {Event} event The event data.
+       */
+      function beginInit(event: Event & { target: HTMLInputElement }) {
+        setAttrModule<HTMLInputElement>(event.target, targets.output).init();
+      }
+    }
+  };
+
+  return new Controller({ name, targets, events });
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,9 +1,11 @@
 import disable from './if.controller.disable';
+import setAttr from './if.controller.setAttr';
 import validateInput from './if.controller.validateInput';
 import validateForm from './if.controller.validateForm';
 
 export {
   disable,
+  setAttr,
   validateInput,
   validateForm
 };

--- a/src/if.const.ts
+++ b/src/if.const.ts
@@ -12,7 +12,8 @@ export const SELECTORS: Global.ConfigObject = {
     condition: '[data-if-disable-condition]'
   },
   setAttr: {
-    target: '[data-if-set-attr]'
+    target: '[data-if-set-attr]',
+    output: '[data-if-set-attr-output]'
   },
   setContent: {
     target: '[data-if-set-content]'

--- a/src/if.utils.ts
+++ b/src/if.utils.ts
@@ -110,7 +110,7 @@ export function createDataFieldSelector(
     selectorString = selectorString.slice(1);
   }
 
-  return `[${dataAttr}${operator}"${selectorString}"]`;
+  return `[data-${dataAttr}${operator}"${selectorString}"]`;
 }
 
 /**

--- a/src/modules/if.module.setAttr.ts
+++ b/src/modules/if.module.setAttr.ts
@@ -1,0 +1,160 @@
+import { Global } from '../../typings.d';
+
+/**
+ * @file The `setAttr` module.
+ *
+ * @author Justin Toon
+ * @version 0.1.0
+ * @license MIT
+ */
+
+/**
+ * A module for setting an attribute value on an element in response to an event.
+ *
+ * @module innerface/setAttr
+ * @since 0.1.0
+ */
+
+import {
+  filter,
+  find,
+  forEach,
+  includes,
+  isArray,
+  isEmpty,
+  last
+} from 'lodash-es';
+import * as inflection from 'inflection';
+
+import { STATES } from '../if.const';
+import { createDataFieldSelector, decodeString } from '../if.utils';
+
+/**
+ * The `setAttr` module.
+ *
+ * @param {HTMLInputElement} source
+ */
+export default function setAttr<T extends HTMLElement>(
+  source: T,
+  targets: NodeListOf<HTMLElement>
+): {
+  init: () => void;
+} {
+  function getValue(element: HTMLElement, key?: string): string {
+    if (element.tagName === 'SELECT') {
+      const options = element.querySelectorAll('option') as NodeListOf<
+        HTMLOptionElement
+      >;
+      const option = find(
+        options,
+        option => option.selected && option.selected === true
+      );
+
+      return option.label || option.title || option.innerText;
+    } else if (element.tagName === 'INPUT') {
+      const inputElement = element as HTMLInputElement;
+      return inputElement.value;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Prepare and return the final value.
+   *
+   * @protected
+   * @param {HTMLElement} element The element to inspect and evaluate.
+   * @param {string} value The value provided to set.
+   * @param {string} attr The attribute to set.
+   *
+   * @returns {string}
+   */
+  function prepareValue(
+    element: HTMLElement,
+    value: string,
+    attr: string
+  ): string {
+    let currentValue;
+
+    if (attr === 'class') {
+      const currentClassList = [].forEach.call(element.classList).split(' ');
+
+      // if the provided value starts with `!`, always remove it
+      if (value.startsWith('!')) {
+        value = value.slice(1);
+        return currentClassList.filter(c => c !== value).join(' ');
+      } else {
+        // when setting a class, we want to dedupe the class list — insert it if not
+        // present, or remove it without affecting the other items.
+        const newClassList = includes(currentClassList, value)
+          ? currentClassList.filter(v => v !== value)
+          : currentClassList.concat([value]);
+
+        return newClassList.join(' ');
+      }
+    }
+
+    // if all the other conditions fail, just return the value with no
+    // transformation.
+    return value;
+  }
+
+  /**
+   * Identify the target element and value to write, and then write it.
+   *
+   * @param attrs {string[]} The attribute name as an array of strings.
+   * @param index {number} The current iteration index.
+   */
+  function writeAttr(attrs: string[], index: number) {
+    const target = attrs.shift(); // the first value in the array is the target name
+    const targetElement = document.querySelector(
+      createDataFieldSelector(target, 'ifSetAttrOutput')
+    ) as HTMLElement;
+
+    attrs.forEach(prop => {
+      const attrArray = inflection
+        .transform(prop, ['underscore', 'dasherize'])
+        .split('-');
+      const key: string | undefined =
+        attrArray.length > 1 ? last(attrArray) : undefined;
+      const attr: string = attrArray.join('');
+      let value: string;
+
+      if (source.dataset.ifSetAttrValue) {
+        if (isArray(source.dataset.ifSetAttrValue)) {
+          value = source.dataset.ifSetAttrValue[index];
+        } else {
+          value = source.dataset.ifSetAttrValue;
+        }
+      } else {
+        value = getValue(source, key);
+      }
+
+      if (['value', 'class'].some(a => a === attr)) {
+        value = prepareValue(targetElement, value, attr);
+      }
+
+      targetElement.setAttribute(attr, value);
+    });
+  }
+
+  /**
+   * Initialize the module.
+   */
+  function init() {
+    let params: string[][];
+
+    if (source.dataset.ifSetAttr) {
+      // split the attribute value for each item
+      params = source.dataset.ifSetAttr
+        .split(',')
+        .map((param): string[] => param.split('|'));
+
+      if (params) {
+        params.forEach(writeAttr);
+      }
+    }
+  }
+
+  return { init };
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -18,7 +18,7 @@ export namespace Global {
     };
   }
 
-  export interface NodeListObject<T> {
+  export interface NodeListObject<T extends HTMLElement> {
     [key: string]: NodeListOf<T>;
   }
 


### PR DESCRIPTION
To trigger, attach `data-if-set-attr` to an element which can accept a change event, and give it a set of values in the following format:

```
nameOfOutput|attrName,anotherNameOfOutput,attrName
```

As a comma separated list of items, this will separately trigger elements with the attribute `data-if-set-attr-output`, and a value which matches the string before the pipe. The value of the source element will be passed to all target elements, and inserted as an attribute matching the name after the pipe. (Camelcasing will be converted to dashcase.) This can be any standard attribute, or a custom data attribute.